### PR TITLE
Add setHeight method

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -16,6 +16,14 @@ function setScrollableViewViews(_views) {
   }
 };
 
+// Exports setHeight
+exports.setHeight = setControlHeight;
+function setControlHeight(_value) {
+  if(_value) {
+    $.container.setHeight(_value);
+  }
+};
+
 // Set the view parameters as children of the ScrollableView
 setScrollableViewViews(args.children);
 


### PR DESCRIPTION
In order to allow, by code, to set `height=0` if you have no views to add (e.g., you are calling an API and have no items to show), add setHeight method to allow `$.scrll.setHeight(0)` after the API call and _hide_ the control.
