### PR TITLE
New setHeight() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Download this repository and consult the [Alloy Documentation](http://docs.appce
 ### Methods
 
 * setView(View[])
+* setHeight(value) -- you can set initial height as property and modify later with this method
 * setCurrentPage(Number)
 * moveNext -- goes to next page
 * movePrevious -- goes to previous page


### PR DESCRIPTION
If you have no views to add after widget inicialization (e.g., you are calling an API and have no items to show), add setHeight method to allow $.scrll.setHeight(0) after the API call and hide the control.
